### PR TITLE
fix: fetching vocab using $eq, fix search using 3-tier behaviour

### DIFF
--- a/src/components/layout/Searchbar/SearchInput.js
+++ b/src/components/layout/Searchbar/SearchInput.js
@@ -4,7 +4,7 @@ import Select, { components } from "react-select";
 import { useNavigate } from "react-router-dom";
 import i18next from "i18next";
 import { Store } from "../../../flux";
-import apiClient from "../../../services/api/client";
+import { searchVocabs } from "../../../services/api/searchVocabAPI";
 
 const SearchInput = () => {
   const { t } = useTranslation();
@@ -25,15 +25,6 @@ const SearchInput = () => {
   const DEBOUNCE_DELAY = 500;
   const CACHE_TTL = 1000 * 60 * 2; // 2 minutes
   const MAX_CACHE_ENTRIES = 20; // cache size
-
-  const transformData = (data) => (
-    data.map(item => ({
-      groupCategory: item.category_group?.GroupCategory || `${item.Group}/${item.Category}`,
-      word: item.Word || '',
-      perkataan: item.Perkataan || ''
-    }))
-    // Removed filter for VALID_RELEASES
-  );
 
   const clearSearchCache = () => {
     queryCacheRef.current = {};
@@ -86,17 +77,11 @@ const SearchInput = () => {
 
     try {
       if (isMounted.current) setLoading(true);
-      const field = currentLanguage === "en" ? "Word" : "Perkataan";
-      const res = await apiClient.get(`/api/bims?populate=category_group&filters[${field}][$containsi]=${encodeURIComponent(query)}`);
-      const results = transformData(res.data?.data || []);
-
-      const sortedResults = results.sort((a, b) =>
-        currentLanguage === "en" ? a.word.localeCompare(b.word) : a.perkataan.localeCompare(b.perkataan)
-      );
+      const results = await searchVocabs(query);
 
       if (isMounted.current && requestId === latestRequestIdRef.current) {
-        setOptions(sortedResults);
-        cacheResults(query, sortedResults);
+        setOptions(results);
+        cacheResults(query, results);
       }
     } catch (err) {
       console.error("Search fetch error:", err);

--- a/src/services/api/searchVocabAPI.js
+++ b/src/services/api/searchVocabAPI.js
@@ -1,0 +1,78 @@
+import apiClient from "./client";
+import cookies from "js-cookie";
+
+const getCurrentLocale = () => cookies.get("i18next") || "en";
+
+const transformItem = (item) => {
+    const categoryGroup = item.category_group || {};
+    return {
+        id: item.id,
+        kumpulanKategori:
+            categoryGroup.KumpulanKategori || `${item.Kumpulan}/${item.Kategori}`,
+        groupCategory:
+            categoryGroup.GroupCategory || `${item.Group}/${item.Category}`,
+        word: item.Word || "",
+        perkataan: item.Perkataan || "",
+        video: item.Video || "",
+        imgStatus: item.Image_Status || "",
+        exampleSentence: item.Example_Sentence || "",
+        contohAyat: item.Contoh_Ayat || "",
+    };
+};
+
+const dedupe = (arr) => {
+    const seen = new Set();
+    const out = [];
+
+    for (const item of arr) {
+        const key = `${item.word}|${item.perkataan}|${item.groupCategory}`;
+        if (!seen.has(key)) {
+            seen.add(key);
+            out.push(item);
+        }
+    }
+
+    return out;
+};
+
+export const searchVocabs = async (query) => {
+    const trimmed = query.trim();
+    if (trimmed.length < 2) return [];
+
+    const locale = getCurrentLocale();
+    const field = locale === "ms" ? "Perkataan" : "Word";
+    const encoded = encodeURIComponent(trimmed);
+
+    const eqUrl = `/api/bims?populate=category_group&filters[${field}][$eqi]=${encoded}&pagination[pageSize]=1`;
+    const startsUrl = `/api/bims?populate=category_group&filters[${field}][$startsWithi]=${encoded}&pagination[pageSize]=50`;
+
+    const [eqRes, startsRes] = await Promise.all([
+        apiClient.get(eqUrl),
+        apiClient.get(startsUrl),
+    ]);
+
+    const exactItems = eqRes.data?.data?.map(transformItem) ?? [];
+    const prefixItems = startsRes.data?.data?.map(transformItem) ?? [];
+
+    const sortByLocale = (items) =>
+        items.slice().sort((a, b) =>
+            locale === "ms"
+                ? a.perkataan.localeCompare(b.perkataan)
+                : a.word.localeCompare(b.word)
+        );
+
+    const sortedExact = sortByLocale(exactItems);
+    const sortedPrefix = sortByLocale(prefixItems);
+
+    let combined = dedupe([...sortedExact, ...sortedPrefix]);
+
+    if (combined.length < 50) {
+        const containsUrl = `/api/bims?populate=category_group&filters[${field}][$containsi]=${encoded}&pagination[pageSize]=50`;
+        const containsRes = await apiClient.get(containsUrl);
+        const containsItems = containsRes.data?.data?.map(transformItem) ?? [];
+        const sortedContains = sortByLocale(containsItems);
+        combined = dedupe([...combined, ...sortedContains]);
+    }
+
+    return combined;
+};

--- a/src/services/api/vocabAPI.js
+++ b/src/services/api/vocabAPI.js
@@ -47,7 +47,7 @@ export const fetchVocabDetailFromAPI = async (vocabName) => {
 
   const formatted = formatString(vocabName);
   const searchToken = vocabName.trim();
-  const endpoint = `/api/bims?populate=category_group&filters[Word][$containsi]=${encodeURIComponent(searchToken)}`;
+  const endpoint = `/api/bims?populate=category_group&filters[Word][$eq]=${encodeURIComponent(searchToken)}`;
 
   try {
     const cachedData = findVocabInAlphabetData(vocabName);
@@ -122,7 +122,7 @@ export const getVocabDetail = async (vocabName) => {
       vocabCacheTimestamps.set(vocabName, now);
       return fetched;
     }
-    
+
     // Last-resort fallback to Store
 
     const storeData = Store.getVocabDetail(vocabName);


### PR DESCRIPTION
## Summary
Implement prioritized 3-tier search behavior for vocabulary lookup.

## What changed
### Added [searchVocabAPI.js]

- Performs:
1. exact match search
2. starts-with prefix search
3. contains search only when needed

- Deduplicates results across tiers
- Sorts within each tier by locale
- Updated [SearchInput.js]
- Replaced the old single $containsi search call
- Now uses [searchVocabs(query)]
- Preserves existing debouncing, loading state, and cache behavior

## Why
This ensures:
- exact hits are always surfaced first
- prefix matches are prioritized next
- middle-of-word matches only appear when there is room
- search results are still stable and locale-aware

## Testing
- Verified no file errors in updated files
- Confirmed search helper and component wiring are correct